### PR TITLE
src/trackmp3.cpp: fix build against gcc-11

### DIFF
--- a/src/trackmp3.cpp
+++ b/src/trackmp3.cpp
@@ -455,7 +455,7 @@ int TrackMp3::findFrame(int pos) {
             temp = m_qSeekList.at(--frameIdx);
     }
 
-    if (temp>0) {
+    if (temp) {
         return temp->pos;
     } else {
         return 0;


### PR DESCRIPTION
On gcc-11 build fails as:

```
../src/trackmp3.cpp: In member function 'int TrackMp3::findFrame(int)':
../src/trackmp3.cpp:458:13: error:
  ordered comparison of pointer with integer zero ('MadSeekFrameType*' and 'int')
  458 |     if (temp>0) {
      |         ~~~~^~
```

The fix changes pointer-to-int comparison to NULL comparison.

Reported-by: Agostino Sarubbo
Bug: https://bugs.gentoo.org/740328